### PR TITLE
[DOC] Fix typo in IDs query doc

### DIFF
--- a/_query-dsl/term/ids.md
+++ b/_query-dsl/term/ids.md
@@ -31,4 +31,4 @@ The query accepts the following parameter.
 
 Parameter | Data type | Description
 :--- | :--- | :---
-`value` | Array of strings | The document IDs to search for. Required.
+`values` | Array of strings | The document IDs to search for. Required.


### PR DESCRIPTION
### Description
I fixed the parameter (`value` -> `values`) for IDs query.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
